### PR TITLE
Use big VM

### DIFF
--- a/run_rechunk.sh
+++ b/run_rechunk.sh
@@ -1,4 +1,3 @@
-#COILED memory 32GiB
 #COILED disk-size 120GB
 #COILED ntasks 1 
 #COILED workspace esip-lab

--- a/submit_coiled_batch.sh
+++ b/submit_coiled_batch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 coiled batch run ./run_rechunk.sh  \
 	--arm \
-	--worker_vm_types=["c7g.8xlarge"] \
+	--vm_type "c7g.8xlarge" \
 	--secret-env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
 	--secret-env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY  


### PR DESCRIPTION
This PR updates the CLI option for specific the VM type to be `--vm-type` instead of `--worker_vm_types` (not supported). I was looking at your most recent run https://cloud.coiled.io/clusters/684396/account/esip-lab/infrastructure?workspace=esip-lab and noticed it was running on an `m6i.large` (really small) but I think you were intended to run on a `c7g.8xlarge` instance instead. 