### PR TITLE
Consolidate coiled batch options

### DIFF
--- a/ERA5-rechunker-AWS.py
+++ b/ERA5-rechunker-AWS.py
@@ -1,6 +1,17 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+#COILED name rechunking
+#COILED disk-size 120GB
+#COILED ntasks 1
+#COILED workspace esip-lab
+#COILED software pangeo-arm
+#COILED region us-east-1
+#COILED arm True
+#COILED vm-type r7g.8xlarge
+#COILED secret-env AWS_ACCESS_KEY_ID
+#COILED secret-env AWS_SECRET_ACCESS_KEY
+
 
 if __name__ == "__main__":
 

--- a/run_rechunk.sh
+++ b/run_rechunk.sh
@@ -1,8 +1,0 @@
-#COILED disk-size 120GB
-#COILED ntasks 1 
-#COILED workspace esip-lab
-#COILED software pangeo-arm
-#COILED region us-east-1
-#COILED arm True
-#COILED vm-type r7g.8xlarge
-python ERA5-rechunker-AWS.py

--- a/submit_coiled_batch.sh
+++ b/submit_coiled_batch.sh
@@ -1,5 +1,2 @@
 #!/bin/bash
-coiled batch run ./run_rechunk.sh  \
-	--name rechunking \
-	--secret-env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-	--secret-env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY  
+coiled batch run python ERA5-rechunker-AWS.py


### PR DESCRIPTION
@rsignell this is the sort of consolidation I was talking about. You can add the `#COILED` comments directly to your Python script and avoid the need for an intermediate `run_rechunk.sh` file

Btw, we have some docs now https://docs.coiled.io/user_guide/batch.html 

xref https://github.com/OpenScienceComputing/rechunk-jobarray/issues/2